### PR TITLE
fix: improve deployment script to maintain parallel environments

### DIFF
--- a/.github/workflows/backend-ci-cd.yml
+++ b/.github/workflows/backend-ci-cd.yml
@@ -53,6 +53,13 @@ jobs:
     needs: build-and-push
     if: github.event_name == 'push' && (github.ref_name == 'dev' || github.ref_name == 'staging' || github.ref_name == 'master')
     steps:
+      - name: Debug Info
+        run: |
+          echo "Event name: ${{ github.event_name }}"
+          echo "Ref name: ${{ github.ref_name }}"
+          echo "Ref: ${{ github.ref }}"
+          echo "Branch: ${GITHUB_REF#refs/heads/}"
+          
       - name: Deploy to EC2
         uses: appleboy/ssh-action@v1.0.0
         with:
@@ -63,7 +70,7 @@ jobs:
             # Pull da nova imagem
             docker pull ${{ secrets.DOCKER_USERNAME }}/backend-api:${{ needs.build-and-push.outputs.tag }}
             
-            # Para TODOS os containers que usam a porta específica
+            # Para apenas containers que usam a porta específica deste ambiente
             PORT=${{ needs.build-and-push.outputs.port }}
             CONTAINER_USING_PORT=$(docker ps --format "table {{.Names}}\t{{.Ports}}" | grep ":${PORT}->" | awk '{print $1}' | head -1)
             
@@ -73,21 +80,19 @@ jobs:
               docker rm $CONTAINER_USING_PORT || true
             fi
             
-            # Para e remove também o container específico do ambiente (por precaução)
+            # Para e remove APENAS o container específico deste ambiente
+            echo "🛑 Parando container específico: ${{ needs.build-and-push.outputs.container_name }}"
             docker stop ${{ needs.build-and-push.outputs.container_name }} || true
             docker rm ${{ needs.build-and-push.outputs.container_name }} || true
             
-            # Para containers antigos que podem ter nomes similares
-            docker ps -a --format "{{.Names}}" | grep -E "backend-api|backend_api" | xargs -I {} docker stop {} 2>/dev/null || true
-            docker ps -a --format "{{.Names}}" | grep -E "backend-api|backend_api" | xargs -I {} docker rm {} 2>/dev/null || true
-            
-            # Remove imagens antigas para economizar espaço
+            # Remove apenas imagens não utilizadas (não afeta outros containers)
             docker image prune -f
             
             # Aguarda um pouco para liberar a porta
             sleep 3
             
             # Executa o novo container
+            echo "🚀 Iniciando container: ${{ needs.build-and-push.outputs.container_name }} na porta ${{ needs.build-and-push.outputs.port }}"
             docker run -d \
               --name ${{ needs.build-and-push.outputs.container_name }} \
               -p ${{ needs.build-and-push.outputs.port }}:3001 \
@@ -97,10 +102,14 @@ jobs:
             # Aguarda alguns segundos para o container inicializar
             sleep 10
             
+            # Mostra todos os containers rodando (para debug)
+            echo "📋 Containers atualmente rodando:"
+            docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
+            
             # Verifica se o container está rodando
             if docker ps | grep -q ${{ needs.build-and-push.outputs.container_name }}; then
               echo "✅ Container ${{ needs.build-and-push.outputs.container_name }} está rodando na porta ${{ needs.build-and-push.outputs.port }}"
-              docker logs --tail 20 ${{ needs.build-and-push.outputs.container_name }}
+              docker logs --tail 10 ${{ needs.build-and-push.outputs.container_name }}
             else
               echo "❌ Falha ao iniciar o container"
               docker logs ${{ needs.build-and-push.outputs.container_name }}


### PR DESCRIPTION
- Remove aggressive container cleanup that was stopping all backend containers
- Now only stops containers using the specific port or with exact container name
- Enables dev, staging, and prod environments to run in parallel
- Add better logging and debug info for deployment process